### PR TITLE
修改了几个样式在移动设备上能够适配

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _config.yml
 *.iml
 .idea
+.DS_Store

--- a/layout/common/header.ejs
+++ b/layout/common/header.ejs
@@ -24,15 +24,16 @@
             <%- partial('search/index') %>
         </div>
     </div>
+
     <div id="main-nav-mobile" class="header-sub header-inner">
         <table class="menu outer">
             <tr>
                 <% for (var i in theme.menu) { %>
                     <td><a class="main-nav-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a></td>
                 <% } %>
-                <td>
-                    <%- partial('search/index-mobile') %>
-                </td>
+                <!--<td>-->
+                    <!--<%- partial('search/index-mobile') %>-->
+                <!--</td>-->
             </tr>
         </table>
     </div>

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -243,17 +243,15 @@ div .article-more-link
     margin-left: 20px
     .fa-share
         margin-right: 5px
-
 #article-nav
     clearfix()
     position: relative
-    @media mq-normal
-        margin: block-margin 0
-        &:before
-            absolute-center(8px)
-            content: ""
-            border-radius: 50%
-            background: color-default + #222
+    margin: block-margin 0
+    &:before
+        absolute-center(8px)
+        content: ""
+        border-radius: 50%
+        background: color-default + #222
 
 .article-nav-link-wrap
     text-decoration: none
@@ -264,21 +262,53 @@ div .article-more-link
     display: block
     &:hover
         color: color-default
-    @media mq-normal
-        width: 50%
-        margin-top: 0
+    width: 50%
+    margin-top: 0
 
 #article-nav-newer
-    @media mq-normal
-        float: left
-        text-align: right
-        padding-right: 20px
+    float: left
+    text-align: right
+    padding-right: 20px
 
 #article-nav-older
-    @media mq-normal
-        float: right
-        text-align: left
-        padding-left: 20px
+    float: right
+    text-align: left
+    padding-left: 20px
+//#article-nav
+//    clearfix()
+//    position: relative
+//    @media mq-normal
+//        margin: block-margin 0
+//        &:before
+//            absolute-center(8px)
+//            content: ""
+//            border-radius: 50%
+//            background: color-default + #222
+//
+//.article-nav-link-wrap
+//    text-decoration: none
+//    color: color-grey
+//    box-sizing: border-box
+//    margin-top: block-margin
+//    text-align: center
+//    display: block
+//    &:hover
+//        color: color-default
+//    @media mq-normal
+//        width: 50%
+//        margin-top: 0
+//
+//#article-nav-newer
+//    @media mq-normal
+//        float: left
+//        text-align: right
+//        padding-right: 20px
+//
+//#article-nav-older
+//    @media mq-normal
+//        float: right
+//        text-align: left
+//        padding-left: 20px
 
 .article-nav-caption
     letter-spacing: 2px

--- a/source/css/_partial/header.styl
+++ b/source/css/_partial/header.styl
@@ -121,8 +121,8 @@ $nav-link
             line-height: logo-height
 
 #search-form-wrap
-    @media mq-mini
-        display: none
+    //@media mq-mini
+    //    display: none
     @extend $header-block
     @extend $header-block-right
     .search-form
@@ -182,15 +182,16 @@ $nav-link
         clearfix()
         margin: 0
         height: header-sub-height
-        .search-form-input
-            display: none
-            @media mq-mini
-                display: block
-            padding: 0 10px
-            margin-right: 15px
-            height: header-sub-height - 6
-            line-height: header-sub-height - 6
-            border-radius: ((header-sub-height - 6)/2)
-            &::-webkit-search-results-decoration
-            &::-webkit-search-cancel-button
-                -webkit-appearance: none
+        //.search-form-input
+        //    display: none
+        //    @media mq-mini
+        //        float: left
+        //        display: block
+        //    padding: 0 10px
+        //    margin-right: 15px
+        //    height: header-sub-height - 6
+        //    line-height: header-sub-height - 6
+        //    border-radius: ((header-sub-height - 6)/2)
+        //    &::-webkit-search-results-decoration
+        //    &::-webkit-search-cancel-button
+        //        -webkit-appearance: none


### PR DESCRIPTION
使用主题过程中，发现在移动端适配不是很好，因此修改了两处地方的样式。并且将header.js处对应标签删掉。
1.将搜索框统一上置
1.1 改前
![搜索框改前](http://owmwquuej.bkt.clouddn.com/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202017-09-27%2000.05.35.png)
1.2 改后
![搜索框改后](http://owmwquuej.bkt.clouddn.com/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202017-09-27%2000.11.36.png)
2.将上下篇文章的导航修改成与pc端一致
2.1 改前：上下分栏
![改前：上下分栏](http://owmwquuej.bkt.clouddn.com/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202017-09-27%2000.05.51.png)
2.2 改后：与pc端一致，左右分栏
![改后：与pc端一致，左右分栏](http://owmwquuej.bkt.clouddn.com/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202017-09-27%2000.11.44.png)